### PR TITLE
DataScrollerRenderer loading data twice on render fixed

### DIFF
--- a/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
+++ b/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
@@ -25,8 +25,7 @@ import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
 
 public class DataScrollerRenderer extends CoreRenderer {
-
-    @Override
+   
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
         DataScroller ds = (DataScroller) component;
 
@@ -46,8 +45,7 @@ public class DataScrollerRenderer extends CoreRenderer {
             encodeScript(context, ds, chunkSize);
         }
     }
-    
-    @Override
+        
     protected void encodeMarkup(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = ds.getClientId(context);

--- a/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
+++ b/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
@@ -47,6 +47,7 @@ public class DataScrollerRenderer extends CoreRenderer {
         }
     }
     
+    @Override
     protected void encodeMarkup(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = ds.getClientId(context);
@@ -55,57 +56,83 @@ public class DataScrollerRenderer extends CoreRenderer {
         UIComponent loader = ds.getFacet("loader");
         String contentCornerClass = null;
         String containerClass = inline ? DataScroller.INLINE_CONTAINER_CLASS : DataScroller.CONTAINER_CLASS;
-        
+
         String style = ds.getStyle();
         String userStyleClass = ds.getStyleClass();
         String styleClass = (userStyleClass == null) ? containerClass : containerClass + " " + userStyleClass;
-        
-        if(ds.isLazy()) {
+        boolean alreadyLoaded = false;
+        if (ds.isLazy()) {
+            alreadyLoaded = true;
             loadLazyData(ds, 0, chunkSize);
         }
-        
+
         writer.startElement("div", ds);
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("class", styleClass, null);
-        if(style != null) {
+        if (style != null) {
             writer.writeAttribute("style", styleClass, null);
         }
-        
-        if(header != null && header.isRendered()) {
+
+        if (header != null && header.isRendered()) {
             writer.startElement("div", ds);
             writer.writeAttribute("class", DataScroller.HEADER_CLASS, null);
             header.encodeAll(context);
             writer.endElement("div");
-            
+
             contentCornerClass = "ui-corner-bottom";
-        }
-        else {
+        } else {
             contentCornerClass = "ui-corner-all";
         }
-        
+
         writer.startElement("div", ds);
         writer.writeAttribute("class", DataScroller.CONTENT_CLASS + " " + contentCornerClass, null);
-        if(inline) {
+        if (inline) {
             writer.writeAttribute("style", "height:" + ds.getScrollHeight() + "px", null);
         }
-        
+
         writer.startElement("ul", ds);
         writer.writeAttribute("class", DataScroller.LIST_CLASS, null);
-        loadChunk(context, ds, 0, chunkSize);
+        loadChunk(context, ds, 0, chunkSize, alreadyLoaded);
         ds.setRowIndex(-1);
         writer.endElement("ul");
-        
+
         writer.startElement("div", null);
         writer.writeAttribute("class", DataScroller.LOADER_CLASS, null);
-        if(loader != null && loader.isRendered()) {
+        if (loader != null && loader.isRendered()) {
             loader.encodeAll(context);
-        }     
+        }
         writer.endElement("div");
-        
+
         writer.endElement("div");
-        
+
         writer.endElement("div");
     }
+
+   
+    protected void loadChunk(FacesContext context, DataScroller ds, int start, int size) throws IOException {
+        loadChunk(context, ds, start, size, false); // alreadyLoaded is false by default
+    }
+
+    protected void loadChunk(FacesContext context, DataScroller ds, int start, int size, boolean alreadyLoaded) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+
+        if (ds.isLazy() && !alreadyLoaded) {
+            loadLazyData(ds, start, size);
+        }
+
+        for (int i = start; i < (start + size); i++) {
+            ds.setRowIndex(i);
+            if (!ds.isRowAvailable()) {
+                break;
+            }
+
+            writer.startElement("li", null);
+            writer.writeAttribute("class", DataScroller.ITEM_CLASS, null);
+            renderChildren(context, ds);
+            writer.endElement("li");
+        }
+        ds.setRowIndex(-1);
+    }    
     
     protected void encodeScript(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
         String clientId = ds.getClientId(context);
@@ -119,27 +146,6 @@ public class DataScrollerRenderer extends CoreRenderer {
             .attr("mode", ds.getMode(), "document")
             .attr("buffer", ds.getBuffer())
             .finish();
-    }
-    
-    protected void loadChunk(FacesContext context, DataScroller ds, int start, int size) throws IOException {
-        ResponseWriter writer = context.getResponseWriter();
-        
-        if(ds.isLazy()) {
-            loadLazyData(ds, start, size);
-        }
-        
-        for(int i = start; i < (start + size); i++) {
-            ds.setRowIndex(i);
-            if(!ds.isRowAvailable()) {
-                break;
-            }
-            
-            writer.startElement("li", null);
-            writer.writeAttribute("class", DataScroller.ITEM_CLASS, null);
-            renderChildren(context, ds);
-            writer.endElement("li");
-        }
-        ds.setRowIndex(-1);
     }
     
     protected void loadLazyData(DataScroller ds, int start, int size) {

--- a/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
+++ b/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
@@ -25,7 +25,8 @@ import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
 
 public class DataScrollerRenderer extends CoreRenderer {
-   
+
+    @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
         DataScroller ds = (DataScroller) component;
 
@@ -45,7 +46,7 @@ public class DataScrollerRenderer extends CoreRenderer {
             encodeScript(context, ds, chunkSize);
         }
     }
-        
+
     protected void encodeMarkup(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = ds.getClientId(context);
@@ -106,7 +107,6 @@ public class DataScrollerRenderer extends CoreRenderer {
         writer.endElement("div");
     }
 
-   
     protected void encodeScript(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
         String clientId = ds.getClientId(context);
         String loadEvent = ds.getFacet("loader") == null ? "scroll" : "manual";
@@ -145,7 +145,7 @@ public class DataScrollerRenderer extends CoreRenderer {
         }
         ds.setRowIndex(-1);
     }    
-    
+
     protected void loadLazyData(DataScroller ds, int start, int size) {
         LazyDataModel lazyModel = (LazyDataModel) ds.getValue();
         

--- a/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
+++ b/src/main/java/org/primefaces/component/datascroller/DataScrollerRenderer.java
@@ -109,6 +109,20 @@ public class DataScrollerRenderer extends CoreRenderer {
     }
 
    
+    protected void encodeScript(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
+        String clientId = ds.getClientId(context);
+        String loadEvent = ds.getFacet("loader") == null ? "scroll" : "manual";
+        
+        WidgetBuilder wb = getWidgetBuilder(context);
+        wb.init("DataScroller", ds.resolveWidgetVar(), clientId)
+            .attr("chunkSize", chunkSize)
+            .attr("totalSize", ds.getRowCount())
+            .attr("loadEvent", loadEvent)
+            .attr("mode", ds.getMode(), "document")
+            .attr("buffer", ds.getBuffer())
+            .finish();
+    }
+
     protected void loadChunk(FacesContext context, DataScroller ds, int start, int size) throws IOException {
         loadChunk(context, ds, start, size, false); // alreadyLoaded is false by default
     }
@@ -133,20 +147,6 @@ public class DataScrollerRenderer extends CoreRenderer {
         }
         ds.setRowIndex(-1);
     }    
-    
-    protected void encodeScript(FacesContext context, DataScroller ds, int chunkSize) throws IOException {
-        String clientId = ds.getClientId(context);
-        String loadEvent = ds.getFacet("loader") == null ? "scroll" : "manual";
-        
-        WidgetBuilder wb = getWidgetBuilder(context);
-        wb.init("DataScroller", ds.resolveWidgetVar(), clientId)
-            .attr("chunkSize", chunkSize)
-            .attr("totalSize", ds.getRowCount())
-            .attr("loadEvent", loadEvent)
-            .attr("mode", ds.getMode(), "document")
-            .attr("buffer", ds.getBuffer())
-            .finish();
-    }
     
     protected void loadLazyData(DataScroller ds, int start, int size) {
         LazyDataModel lazyModel = (LazyDataModel) ds.getValue();


### PR DESCRIPTION
`loadChunk` function in DataScrollerRenderer as an additional parameter to evaluate if the data in the data scroller has already been loaded, avoiding duplicate request to the same paginable first page.

Original `loadChunk` function defaults the additional `alreadyLoaded` to `false`.
